### PR TITLE
Camera component and system

### DIFF
--- a/Engine/core/includes/Entity.hpp
+++ b/Engine/core/includes/Entity.hpp
@@ -32,7 +32,7 @@ struct Entity : public std::enable_shared_from_this<Entity> {
   std::weak_ptr<Entity> get_parent_entity();
 
   glm::vec3 get_local_position() const;
-  void set_local_position(const glm::vec3 pos);
+  void set_local_position(glm::vec3 pos);
   glm::vec3 get_world_position() const;
 
   glm::vec3 get_local_rotation() const;

--- a/Engine/core/includes/Scene.hpp
+++ b/Engine/core/includes/Scene.hpp
@@ -4,6 +4,7 @@
 #include "includes/system/SimpleSystem.hpp"
 #include "includes/system/EntitySystem.hpp"
 #include "includes/system/RenderSystem.hpp"
+#include "includes/system/CameraSystem.hpp"
 #include "includes/UUIDManager.hpp"
 #include <boost/uuid/uuid.hpp>
 #include <memory>
@@ -45,9 +46,9 @@ private:
   EntitySystem _entity_system{};
   SimpleSystem _simple_system{};
   RenderSystem _render_system;
+  CameraSystem _camera_system{};
 
   UUIDManager _uuid_manager{};
-  //   WindowManager _wm{}; // will probably end up in engine
 
   std::shared_ptr<Entity> _root;
 };

--- a/Engine/core/includes/Scene.hpp
+++ b/Engine/core/includes/Scene.hpp
@@ -43,12 +43,12 @@ private:
   std::shared_ptr<Entity> create_root(const std::string &name);
   std::shared_ptr<Entity> create_root(const std::string &name, uuid id);
 
-  EntitySystem _entity_system{};
-  SimpleSystem _simple_system{};
-  CameraSystem _camera_system{};
-  RenderSystem _render_system;
+  UUIDManager _uuid_manager;
 
-  UUIDManager _uuid_manager{};
+  EntitySystem _entity_system;
+  SimpleSystem _simple_system;
+  CameraSystem _camera_system;
+  RenderSystem _render_system;
 
   std::shared_ptr<Entity> _root;
 };

--- a/Engine/core/includes/Scene.hpp
+++ b/Engine/core/includes/Scene.hpp
@@ -43,11 +43,11 @@ private:
   std::shared_ptr<Entity> create_root(const std::string &name);
   std::shared_ptr<Entity> create_root(const std::string &name, uuid id);
 
-  UUIDManager _uuid_manager;
+  UUIDManager _uuid_manager{};
 
-  EntitySystem _entity_system;
-  SimpleSystem _simple_system;
-  CameraSystem _camera_system;
+  EntitySystem _entity_system{};
+  SimpleSystem _simple_system{};
+  CameraSystem _camera_system{};
   RenderSystem _render_system;
 
   std::shared_ptr<Entity> _root;

--- a/Engine/core/includes/Scene.hpp
+++ b/Engine/core/includes/Scene.hpp
@@ -45,8 +45,8 @@ private:
 
   EntitySystem _entity_system{};
   SimpleSystem _simple_system{};
-  RenderSystem _render_system;
   CameraSystem _camera_system{};
+  RenderSystem _render_system;
 
   UUIDManager _uuid_manager{};
 

--- a/Engine/core/includes/Scene.hpp
+++ b/Engine/core/includes/Scene.hpp
@@ -47,7 +47,6 @@ private:
   SimpleSystem _simple_system{};
   CameraSystem _camera_system{};
   RenderSystem _render_system;
-  CameraSystem _camera_system{};
 
   UUIDManager _uuid_manager{};
 

--- a/Engine/core/includes/component/CameraComponent.hpp
+++ b/Engine/core/includes/component/CameraComponent.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "includes/component/Component.hpp"
 // #include "includes/system/CameraSystem.hpp"
 

--- a/Engine/core/includes/component/CameraComponent.hpp
+++ b/Engine/core/includes/component/CameraComponent.hpp
@@ -1,0 +1,25 @@
+#include "includes/component/Component.hpp"
+// #include "includes/system/CameraSystem.hpp"
+
+struct CameraSystem;
+
+struct CameraComponent : public Component {
+  CameraComponent(uuid id, Entity *e);
+  CameraComponent(uuid id, Entity *e, float fov);
+
+  void init() override;
+  void update(const float dt) override;
+  void destroy() override;
+
+  inline void set_fov(const float fov) { _fov = fov; }
+  inline float get_fov() const { return _fov; }
+
+  inline bool is_main_camera() { return _is_main_camera; }
+
+private:
+  bool _is_main_camera{false};
+  float _fov{60.f};
+  
+  friend CameraSystem;
+  inline void set_is_main_camera(bool value) { _is_main_camera = value; }
+};

--- a/Engine/core/includes/component/CameraComponent.hpp
+++ b/Engine/core/includes/component/CameraComponent.hpp
@@ -1,4 +1,7 @@
 #include "includes/component/Component.hpp"
+// #include "includes/system/CameraSystem.hpp"
+
+struct CameraSystem;
 
 struct CameraComponent : public Component {
   CameraComponent(uuid id, Entity *e);
@@ -11,6 +14,12 @@ struct CameraComponent : public Component {
   inline void set_fov(const float fov) { _fov = fov; }
   inline float get_fov() const { return _fov; }
 
+  inline bool is_main_camera() { return _is_main_camera; }
+
 private:
+  bool _is_main_camera{false};
   float _fov{60.f};
+  
+  friend CameraSystem;
+  inline void set_is_main_camera(bool value) { _is_main_camera = value; }
 };

--- a/Engine/core/includes/component/CameraComponent.hpp
+++ b/Engine/core/includes/component/CameraComponent.hpp
@@ -1,0 +1,16 @@
+#include "includes/component/Component.hpp"
+
+struct CameraComponent : public Component {
+  CameraComponent(uuid id, Entity *e);
+  CameraComponent(uuid id, Entity *e, float fov);
+
+  void init() override;
+  void update(const float dt) override;
+  void destroy() override;
+
+  inline void set_fov(const float fov) { _fov = fov; }
+  inline float get_fov() const { return _fov; }
+
+private:
+  float _fov{60.f};
+};

--- a/Engine/core/includes/system/CameraSystem.hpp
+++ b/Engine/core/includes/system/CameraSystem.hpp
@@ -5,6 +5,7 @@
 #include "includes/system/System.hpp"
 #include <boost/uuid/uuid.hpp>
 #include <optional>
+#include <memory>
 #include <map>
 
 typedef boost::uuids::uuid uuid;

--- a/Engine/core/includes/system/CameraSystem.hpp
+++ b/Engine/core/includes/system/CameraSystem.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "includes/Entity.hpp"
+#include "includes/component/Component.hpp"
+#include "includes/component/CameraComponent.hpp"
+#include "includes/system/System.hpp"
+#include <boost/uuid/uuid.hpp>
+#include <optional>
+#include <map>
+
+typedef boost::uuids::uuid uuid;
+
+struct CameraSystem : public System {
+  CameraSystem();
+
+  CameraComponent *create_component(uuid id, Entity *e) override;
+  CameraComponent *create_component(uuid id, Entity *e, float fov);
+  bool remove(Component *c) override;
+  bool remove(uuid uuid) override;
+
+  inline const auto &get_components() const { return _components; }
+  std::optional<CameraComponent *> get_component(uuid id);
+
+  void set_main_camera(CameraComponent *cc);
+
+private:
+  std::map<uuid, std::unique_ptr<CameraComponent>> _components{};
+  CameraComponent *_main_camera;
+};

--- a/Engine/core/includes/system/CameraSystem.hpp
+++ b/Engine/core/includes/system/CameraSystem.hpp
@@ -30,5 +30,5 @@ struct CameraSystem : public System {
 
 private:
   std::map<uuid, std::unique_ptr<CameraComponent>> _components{};
-  CameraComponent *_main_camera;
+  CameraComponent *_main_camera = nullptr;
 };

--- a/Engine/core/includes/system/CameraSystem.hpp
+++ b/Engine/core/includes/system/CameraSystem.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include "includes/Entity.hpp"
+#include "includes/component/Component.hpp"
+#include "includes/component/CameraComponent.hpp"
+#include "includes/system/System.hpp"
+#include <boost/uuid/uuid.hpp>
+#include <optional>
+#include <map>
+
+typedef boost::uuids::uuid uuid;
+
+struct CameraSystem : public System {
+  CameraSystem();
+
+  CameraComponent *create_component(uuid id, Entity *e) override;
+  CameraComponent *create_component(uuid id, Entity *e, float fov);
+  bool remove(Component *c) override;
+  bool remove(uuid uuid) override;
+
+  inline const auto &get_components() const { return _components; }
+  std::optional<CameraComponent *> get_component(uuid id);
+
+  void set_main_camera(CameraComponent *cc);
+  inline CameraComponent *get_main_camera() const { return _main_camera; }
+
+  void print();
+
+  void sample_update_move_main_camera(float dt);
+
+private:
+  std::map<uuid, std::unique_ptr<CameraComponent>> _components{};
+  CameraComponent *_main_camera;
+};

--- a/Engine/core/includes/system/CameraSystem.hpp
+++ b/Engine/core/includes/system/CameraSystem.hpp
@@ -21,6 +21,11 @@ struct CameraSystem : public System {
   std::optional<CameraComponent *> get_component(uuid id);
 
   void set_main_camera(CameraComponent *cc);
+  inline CameraComponent *get_main_camera() const { return _main_camera; }
+
+  void print();
+
+  void sample_update_move_main_camera(float dt);
 
 private:
   std::map<uuid, std::unique_ptr<CameraComponent>> _components{};

--- a/Engine/core/includes/system/RenderSystem.hpp
+++ b/Engine/core/includes/system/RenderSystem.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "includes/system/System.hpp"
+#include "includes/system/CameraSystem.hpp"
 #include "includes/component/RenderComponent.hpp"
 #include "includes/ShaderCompiler.hpp"
 #include "includes/WindowManager.hpp"
@@ -33,7 +34,7 @@
  */
 struct RenderSystem : public System {
 
-  explicit RenderSystem(WindowManager *wm);
+  RenderSystem(WindowManager *wm, CameraSystem* cs);
   
   void init();
   void update(const float dt); // represents render
@@ -57,6 +58,7 @@ struct RenderSystem : public System {
 
 private:
   WindowManager *_wm;
+  CameraSystem* _cs;
 
   std::unique_ptr<Shader> program;
 

--- a/Engine/core/includes/system/RenderSystem.hpp
+++ b/Engine/core/includes/system/RenderSystem.hpp
@@ -34,7 +34,7 @@
 struct RenderSystem : public System {
 
   explicit RenderSystem(WindowManager *wm);
-
+  
   void init();
   void update(const float dt); // represents render
   void destroy();

--- a/Engine/core/includes/system/SimpleSystem.hpp
+++ b/Engine/core/includes/system/SimpleSystem.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "includes/utility/SimpleLogger.hpp"
 #include "includes/Entity.hpp"
 #include "includes/component/SimpleComponent.hpp"
 #include "includes/system/System.hpp"

--- a/Engine/core/shaders/computeshaderCircle.glsl
+++ b/Engine/core/shaders/computeshaderCircle.glsl
@@ -8,6 +8,7 @@ uniform float time;
 uniform mat4 Model;
 uniform mat4 View;
 uniform mat4 Projection;
+uniform vec3 cameraPos;
 
 const int hittableCount = 3;
 const int emitterCount = 1;
@@ -344,7 +345,8 @@ void main() {
     float x = float(pixelCoords.x * 2 - dims.x) / dims.x; // transforms to [-1.0, 1.0]
     float y = float(pixelCoords.y * 2 - dims.y) / dims.y; // transforms to [-1.0, 1.0]
 
-    vec3 rayOrigin = vec3(0.0, 10.0, 10.0); // Ray origin should always be camera position. Current camera position is not used
+    //vec3 rayOrigin = vec3(10.0, 10.0, 50.0); // Ray origin should always be camera position. Current camera position is not used
+	vec3 rayOrigin = cameraPos;
 
     //ray in clip
     vec4 rayPixel = vec4(x, y, -1.0, 1.0);

--- a/Engine/core/src/Engine.cpp
+++ b/Engine/core/src/Engine.cpp
@@ -14,12 +14,17 @@ void Engine::init_server() {
 }
 
 void Engine::startLoop() {
+  SimpleLogger::print("Engine::startLoop()");
   float t0, t1, dt;
   while (_wm.shouldClose()) {
+  SimpleLogger::print("Engine::Loop 1");
     t0 = t1;
     t1 = _wm.get_time();
     dt = t1 - t0;
+  SimpleLogger::print("Engine::Loop 2");
     _scene.update(t1);
+  SimpleLogger::print("Engine::Loop 3");
     _wm.update();
+  SimpleLogger::print("Engine::Loop 4");
   }
 }

--- a/Engine/core/src/Engine.cpp
+++ b/Engine/core/src/Engine.cpp
@@ -17,14 +17,10 @@ void Engine::startLoop() {
   SimpleLogger::print("Engine::startLoop()");
   float t0, t1, dt;
   while (_wm.shouldClose()) {
-  SimpleLogger::print("Engine::Loop 1");
     t0 = t1;
     t1 = _wm.get_time();
     dt = t1 - t0;
-  SimpleLogger::print("Engine::Loop 2");
     _scene.update(t1);
-  SimpleLogger::print("Engine::Loop 3");
     _wm.update();
-  SimpleLogger::print("Engine::Loop 4");
   }
 }

--- a/Engine/core/src/Entity.cpp
+++ b/Engine/core/src/Entity.cpp
@@ -96,7 +96,7 @@ void Entity::print(int indent) {
 }
 
 glm::vec3 Entity::get_local_position() const { return _position; }
-void Entity::set_local_position(const glm::vec3 pos) { _position = pos; }
+void Entity::set_local_position(glm::vec3 pos) { _position = pos; }
 glm::vec3 Entity::get_world_position() const {
 
   // std::cout << _parent->get_name() << ": " << _parent.use_count() << "|" <<

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -75,14 +75,14 @@ void Scene::generate_sample_content() {
   // ============== ENTITY + SIMPLE COMPONENT ==============
 
   auto e1 = create_entity("camera");
-  e1->set_local_position(glm::vec3{0, 0, 10});
-  auto e2 = create_entity("cat");
+  e1->set_local_position(glm::vec3{0, 0, +10});
+  auto e2 = create_entity("circle1");
   e2->set_local_rotation(glm::vec3{45, 0, 0});
-  auto e3 = create_entity("cube", e1);
+  auto e3 = create_entity("circle2", e1);
   e3->set_local_position(glm::vec3{-2, 6, 7});
 
   auto new_uuid = _uuid_manager.getNewUUID(&_simple_system);
-  auto c1 = _camera_system.create_component(new_uuid, e1.get());
+  auto c0 = _camera_system.create_component(new_uuid, e1.get());
   new_uuid = _uuid_manager.getNewUUID(&_simple_system);
   auto c2 = _simple_system.create_component(new_uuid, e3.get(), -56);
 

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -74,14 +74,14 @@ void Scene::generate_sample_content() {
   // ============== ENTITY + SIMPLE COMPONENT ==============
 
   auto e1 = create_entity("camera");
-  e1->set_local_position(glm::vec3{0, 1, 2});
-  auto e2 = create_entity("cat");
+  e1->set_local_position(glm::vec3{0, 0, +10});
+  auto e2 = create_entity("circle1");
   e2->set_local_rotation(glm::vec3{45, 0, 0});
-  auto e3 = create_entity("cube", e1);
+  auto e3 = create_entity("circle2", e1);
   e3->set_local_position(glm::vec3{-2, 6, 7});
 
   auto new_uuid = _uuid_manager.getNewUUID(&_simple_system);
-  auto c1 = _simple_system.create_component(new_uuid, e1.get());
+  auto c0 = _camera_system.create_component(new_uuid, e1.get());
   new_uuid = _uuid_manager.getNewUUID(&_simple_system);
   auto c2 = _simple_system.create_component(new_uuid, e3.get(), -56);
 
@@ -119,6 +119,7 @@ void Scene::generate_sample_content() {
   _uuid_manager.print();
   _entity_system.print();
   _render_system.print();
+  _camera_system.print();
 //   _simple_system.print_all_components();
 }
 

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -64,6 +64,7 @@ void Scene::generate_sample_content() {
   _uuid_manager.print();
   _entity_system.print();
   _render_system.print();
+  _camera_system.print();
 //   _simple_system.print_all_components();
 
   SimpleLogger::print("\n");
@@ -74,14 +75,14 @@ void Scene::generate_sample_content() {
   // ============== ENTITY + SIMPLE COMPONENT ==============
 
   auto e1 = create_entity("camera");
-  e1->set_local_position(glm::vec3{0, 1, 2});
+  e1->set_local_position(glm::vec3{0, 0, 10});
   auto e2 = create_entity("cat");
   e2->set_local_rotation(glm::vec3{45, 0, 0});
   auto e3 = create_entity("cube", e1);
   e3->set_local_position(glm::vec3{-2, 6, 7});
 
   auto new_uuid = _uuid_manager.getNewUUID(&_simple_system);
-  auto c1 = _simple_system.create_component(new_uuid, e1.get());
+  auto c1 = _camera_system.create_component(new_uuid, e1.get());
   new_uuid = _uuid_manager.getNewUUID(&_simple_system);
   auto c2 = _simple_system.create_component(new_uuid, e3.get(), -56);
 
@@ -119,6 +120,7 @@ void Scene::generate_sample_content() {
   _uuid_manager.print();
   _entity_system.print();
   _render_system.print();
+  _camera_system.print();
 //   _simple_system.print_all_components();
 }
 

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -75,7 +75,7 @@ void Scene::generate_sample_content() {
   // ============== ENTITY + SIMPLE COMPONENT ==============
 
   auto e1 = create_entity("camera");
-  e1->set_local_position(glm::vec3{0, +10, +10});
+  e1->set_local_position(glm::vec3{+0, +10, +10});
   auto e2 = create_entity("circle1");
   e2->set_local_rotation(glm::vec3{45, 0, 0});
   auto e3 = create_entity("circle2", e1);
@@ -128,4 +128,7 @@ void Scene::generate_sample_content() {
 }
 
 // currently only tell the render system to update itself
-void Scene::update(float dt) { _render_system.update(dt); }
+void Scene::update(float dt) { 
+	_camera_system.sample_update_move_main_camera(dt);
+	_render_system.update(dt); 
+	}

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -76,6 +76,7 @@ void Scene::generate_sample_content() {
 
   auto e1 = create_entity("camera");
   e1->set_local_position(glm::vec3{+0, +10, +10});
+  e1->set_local_rotation(glm::vec3{+0, +15, -5}); // doesn't do anything yet
   auto e2 = create_entity("circle1");
   e2->set_local_rotation(glm::vec3{45, 0, 0});
   auto e3 = create_entity("circle2", e1);

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -82,10 +82,7 @@ void Scene::generate_sample_content() {
   e3->set_local_position(glm::vec3{-2, 6, 7});
 
   auto new_uuid = _uuid_manager.getNewUUID(&_simple_system);
-  auto c0 = _camera_system.create_component(new_uuid, e1.get());
-  new_uuid = _uuid_manager.getNewUUID(&_simple_system);
-  auto c1 = _camera_system.create_component(new_uuid, e2.get());
-//   _camera_system.set_main_camera(c1);
+  auto c1 = _camera_system.create_component(new_uuid, e1.get());
   new_uuid = _uuid_manager.getNewUUID(&_simple_system);
   auto c2 = _simple_system.create_component(new_uuid, e3.get(), -56);
 

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -6,14 +6,14 @@
 #include <format>
 
 Scene::Scene(Engine *e)
-    : _root{create_root("root")}, _render_system{e->get_window_manager()} {
+    : _root{create_root("root")}, _render_system{e->get_window_manager(), &_camera_system} {
   _render_system.init();
 
   generate_sample_content();
 }
 
 Scene::Scene(Engine *e, uuid id)
-    : _root{create_root("root", id)}, _render_system{e->get_window_manager()} {
+    : _root{create_root("root", id)}, _render_system{e->get_window_manager(), &_camera_system} {
   // does not generate sample content
   // this should be called when loading from json
   _render_system.init();
@@ -75,7 +75,7 @@ void Scene::generate_sample_content() {
   // ============== ENTITY + SIMPLE COMPONENT ==============
 
   auto e1 = create_entity("camera");
-  e1->set_local_position(glm::vec3{0, 0, +10});
+  e1->set_local_position(glm::vec3{0, +10, +10});
   auto e2 = create_entity("circle1");
   e2->set_local_rotation(glm::vec3{45, 0, 0});
   auto e3 = create_entity("circle2", e1);
@@ -83,6 +83,9 @@ void Scene::generate_sample_content() {
 
   auto new_uuid = _uuid_manager.getNewUUID(&_simple_system);
   auto c0 = _camera_system.create_component(new_uuid, e1.get());
+  new_uuid = _uuid_manager.getNewUUID(&_simple_system);
+  auto c1 = _camera_system.create_component(new_uuid, e2.get());
+//   _camera_system.set_main_camera(c1);
   new_uuid = _uuid_manager.getNewUUID(&_simple_system);
   auto c2 = _simple_system.create_component(new_uuid, e3.get(), -56);
 

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -6,14 +6,18 @@
 #include <format>
 
 Scene::Scene(Engine *e)
-    : _root{create_root("root")}, _render_system{e->get_window_manager(), &_camera_system} {
+    : _uuid_manager{}, _entity_system{}, _simple_system{}, _camera_system{},
+      _render_system{e->get_window_manager(), &_camera_system},
+      _root{create_root("root")} {
   _render_system.init();
 
   generate_sample_content();
 }
 
 Scene::Scene(Engine *e, uuid id)
-    : _root{create_root("root", id)}, _render_system{e->get_window_manager(), &_camera_system} {
+    : _uuid_manager{}, _entity_system{}, _simple_system{}, _camera_system{},
+      _render_system{e->get_window_manager(), &_camera_system},
+      _root{create_root("root", id)} {
   // does not generate sample content
   // this should be called when loading from json
   _render_system.init();
@@ -65,13 +69,12 @@ void Scene::generate_sample_content() {
   _entity_system.print();
   _render_system.print();
   _camera_system.print();
-//   _simple_system.print_all_components();
+  //   _simple_system.print_all_components();
 
   SimpleLogger::print("\n");
   SimpleLogger::print(std::string(100, '*'));
   SimpleLogger::print("\n");
 
-  
   // ============== ENTITY + SIMPLE COMPONENT ==============
 
   auto e1 = create_entity("camera");
@@ -82,7 +85,7 @@ void Scene::generate_sample_content() {
   auto e3 = create_entity("circle2", e1);
   e3->set_local_position(glm::vec3{-2, 6, 7});
 
-  auto new_uuid = _uuid_manager.getNewUUID(&_simple_system);
+  auto new_uuid = _uuid_manager.getNewUUID(&_camera_system);
   auto c1 = _camera_system.create_component(new_uuid, e1.get());
   new_uuid = _uuid_manager.getNewUUID(&_simple_system);
   auto c2 = _simple_system.create_component(new_uuid, e3.get(), -56);
@@ -108,12 +111,11 @@ void Scene::generate_sample_content() {
                                glm::vec2{0.0f, 1.0f}};
 
   auto root_ptr = get_root().lock();
-  _render_system.create_component(_uuid_manager.getNewUUID(&_render_system), root_ptr.get(),
-                                  v2, u2);
-  _render_system.create_component(_uuid_manager.getNewUUID(&_render_system), root_ptr.get(),
-                                  v3, u3);
+  _render_system.create_component(_uuid_manager.getNewUUID(&_render_system),
+                                  root_ptr.get(), v2, u2);
+  _render_system.create_component(_uuid_manager.getNewUUID(&_render_system),
+                                  root_ptr.get(), v3, u3);
 
-  
   SimpleLogger::print("\n");
   SimpleLogger::print(std::string(100, '*'));
   SimpleLogger::print("\n");
@@ -122,11 +124,18 @@ void Scene::generate_sample_content() {
   _entity_system.print();
   _render_system.print();
   _camera_system.print();
-//   _simple_system.print_all_components();
+  //   _simple_system.print_all_components();
 }
 
 // currently only tell the render system to update itself
-void Scene::update(float dt) { 
-	_camera_system.sample_update_move_main_camera(dt);
-	_render_system.update(dt); 
-	}
+void Scene::update(float dt) {
+	
+  _uuid_manager.print();
+  _entity_system.print();
+  _render_system.print();
+  _camera_system.print();
+  SimpleLogger::print("Scene::update 1");
+  _camera_system.sample_update_move_main_camera(dt);
+  SimpleLogger::print("Scene::update 2");
+  _render_system.update(dt);
+}

--- a/Engine/core/src/Scene.cpp
+++ b/Engine/core/src/Scene.cpp
@@ -6,8 +6,7 @@
 #include <format>
 
 Scene::Scene(Engine *e)
-    : _uuid_manager{}, _entity_system{}, _simple_system{}, _camera_system{},
-      _render_system{e->get_window_manager(), &_camera_system},
+    : _render_system{e->get_window_manager(), &_camera_system},
       _root{create_root("root")} {
   _render_system.init();
 
@@ -15,8 +14,7 @@ Scene::Scene(Engine *e)
 }
 
 Scene::Scene(Engine *e, uuid id)
-    : _uuid_manager{}, _entity_system{}, _simple_system{}, _camera_system{},
-      _render_system{e->get_window_manager(), &_camera_system},
+    : _render_system{e->get_window_manager(), &_camera_system},
       _root{create_root("root", id)} {
   // does not generate sample content
   // this should be called when loading from json
@@ -69,7 +67,6 @@ void Scene::generate_sample_content() {
   _entity_system.print();
   _render_system.print();
   _camera_system.print();
-  //   _simple_system.print_all_components();
 
   SimpleLogger::print("\n");
   SimpleLogger::print(std::string(100, '*'));
@@ -87,8 +84,6 @@ void Scene::generate_sample_content() {
 
   auto new_uuid = _uuid_manager.getNewUUID(&_camera_system);
   auto c1 = _camera_system.create_component(new_uuid, e1.get());
-  new_uuid = _uuid_manager.getNewUUID(&_simple_system);
-  auto c2 = _simple_system.create_component(new_uuid, e3.get(), -56);
 
   // =================== RENDER SYSTEM =====================
 
@@ -124,18 +119,10 @@ void Scene::generate_sample_content() {
   _entity_system.print();
   _render_system.print();
   _camera_system.print();
-  //   _simple_system.print_all_components();
 }
 
 // currently only tell the render system to update itself
 void Scene::update(float dt) {
-	
-  _uuid_manager.print();
-  _entity_system.print();
-  _render_system.print();
-  _camera_system.print();
-  SimpleLogger::print("Scene::update 1");
   _camera_system.sample_update_move_main_camera(dt);
-  SimpleLogger::print("Scene::update 2");
   _render_system.update(dt);
 }

--- a/Engine/core/src/component/CameraComponent.cpp
+++ b/Engine/core/src/component/CameraComponent.cpp
@@ -7,3 +7,4 @@ CameraComponent::CameraComponent(uuid id, Entity *e, float fov)
 
 void CameraComponent::init() {}
 void CameraComponent::update(const float dt) {}
+void CameraComponent::destroy() {}

--- a/Engine/core/src/component/CameraComponent.cpp
+++ b/Engine/core/src/component/CameraComponent.cpp
@@ -6,6 +6,5 @@ CameraComponent::CameraComponent(uuid id, Entity *e, float fov)
     : Component(id, e), _fov(fov) {}
 
 void CameraComponent::init() {}
-
 void CameraComponent::update(const float dt) {}
 void CameraComponent::destroy() {}

--- a/Engine/core/src/component/CameraComponent.cpp
+++ b/Engine/core/src/component/CameraComponent.cpp
@@ -1,0 +1,10 @@
+#include "includes/component/CameraComponent.hpp"
+#include "includes/component/Component.hpp"
+
+CameraComponent::CameraComponent(uuid id, Entity *e) : Component(id, e) {}
+CameraComponent::CameraComponent(uuid id, Entity *e, float fov)
+    : Component(id, e), _fov(fov) {}
+
+void CameraComponent::init() {}
+void CameraComponent::update(const float dt) {}
+void CameraComponent::destroy() {}

--- a/Engine/core/src/component/CameraComponent.cpp
+++ b/Engine/core/src/component/CameraComponent.cpp
@@ -1,0 +1,11 @@
+#include "includes/component/CameraComponent.hpp"
+#include "includes/component/Component.hpp"
+
+CameraComponent::CameraComponent(uuid id, Entity *e) : Component(id, e) {}
+CameraComponent::CameraComponent(uuid id, Entity *e, float fov)
+    : Component(id, e), _fov(fov) {}
+
+void CameraComponent::init() {}
+
+void CameraComponent::update(const float dt) {}
+void CameraComponent::destroy() {}

--- a/Engine/core/src/component/CameraComponent.cpp
+++ b/Engine/core/src/component/CameraComponent.cpp
@@ -7,4 +7,3 @@ CameraComponent::CameraComponent(uuid id, Entity *e, float fov)
 
 void CameraComponent::init() {}
 void CameraComponent::update(const float dt) {}
-void CameraComponent::destroy() {}

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -2,17 +2,25 @@
 #include "includes/utility/SimpleLogger.hpp"
 #include "includes/utility/TablePrinter.hpp"
 #include <boost/uuid/uuid_io.hpp>
+#include <format>
+#include <iostream>
 #include <cmath>
+
+#define GLM_ENABLE_EXPERIMENTAL
+// #include "glm/vec3.hpp"
+#include "glm/ext.hpp"
 
 CameraSystem::CameraSystem() {
   SimpleLogger::print("-- CameraSystem initialized");
 }
 
 CameraComponent *CameraSystem::create_component(uuid id, Entity *e) {
+  SimpleLogger::print("-- create camera component");
   _components[id] = std::make_unique<CameraComponent>(id, e);
   auto ptr = _components[id].get();
   e->add_component(ptr);
-  if (!_main_camera) {
+  std::cout << "MC nullptr?" << (_main_camera == nullptr) << "\n";
+  if (_main_camera == nullptr) {
     set_main_camera(ptr);
   }
   return ptr;
@@ -35,7 +43,8 @@ std::optional<CameraComponent *> CameraSystem::get_component(uuid id) {
 }
 
 void CameraSystem::set_main_camera(CameraComponent *cc) {
-  if (_main_camera) {
+  SimpleLogger::print("-- set main cam");
+  if (_main_camera != nullptr) {
     _main_camera->set_is_main_camera(false);
   }
   _main_camera = cc;
@@ -71,12 +80,22 @@ void CameraSystem::print(){
 }
 
 void CameraSystem::sample_update_move_main_camera(float t1){
+  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 1");
 	if(!_main_camera) return;
 
+  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 2");
 	auto ent = _main_camera->get_entity();
+  SimpleLogger::print(std::format("Entity? {}", ent == nullptr));
+  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 3");
 	auto pos = ent->get_local_position();
+	std::cout << "Pos?" << pos << "\n";
 	
+  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 4");
 	auto dt_sin = std::sin(t1 * 2.5) * 10;
+  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 5");
 	pos.y = dt_sin;
+	std::cout << "Pos?" << pos << "\n";
+  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 6");
 	ent->set_local_position(pos);
+  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 7");
 }

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -1,5 +1,6 @@
 #include "includes/system/CameraSystem.hpp"
 #include "includes/utility/SimpleLogger.hpp"
+#include "includes/utility/TablePrinter.hpp"
 #include <boost/uuid/uuid_io.hpp>
 
 CameraSystem::CameraSystem() {
@@ -43,4 +44,38 @@ void CameraSystem::set_main_camera(CameraComponent *cc) {
       boost::uuids::to_string(_main_camera->get_uuid()),
       _main_camera->get_entity()->get_name(),
       boost::uuids::to_string(_main_camera->get_entity()->get_uuid())));
+}
+
+void CameraSystem::print(){
+  TablePrinter::printElement("CameraComponent UUID", 36);
+  std::cout << " | ";
+  TablePrinter::printElement("fov", 12);
+  std::cout << " | ";
+  TablePrinter::printElement("is main camera", 14);
+  std::cout << "\n";
+  std::cout << std::string(36 + 12 + 14 + 2*3, '=');
+  std::cout << "\n";
+  for (auto const &[uuid, c] : _components) { 
+    std::cout << uuid << " | ";
+    if (c == nullptr) {
+      std::cout << "missing...\n";
+      continue;
+    }
+    TablePrinter::printElement(c->get_fov(), 14);
+    std::cout << " | ";
+    TablePrinter::printElement(c->is_main_camera()? " * " : "", 14);
+    std::cout << "\n";
+  }
+  std::cout << std::endl;
+}
+
+void CameraSystem::sample_update_move_main_camera(float t1){
+	if(!_main_camera) return;
+
+	auto ent = _main_camera->get_entity();
+	auto y = ent->get_local_position().y;
+
+
+
+
 }

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -40,7 +40,7 @@ void CameraSystem::set_main_camera(CameraComponent *cc) {
   _main_camera = cc;
   _main_camera->set_is_main_camera(true);
   SimpleLogger::print(std::format(
-      "Set new main camera ({})\t-> camera is on entity \"{}\"({})",
+      "Set new main camera ({})\n\t-> camera is on entity \"{}\"({})",
       boost::uuids::to_string(_main_camera->get_uuid()),
       _main_camera->get_entity()->get_name(),
       boost::uuids::to_string(_main_camera->get_entity()->get_uuid())));
@@ -61,7 +61,7 @@ void CameraSystem::print(){
       std::cout << "missing...\n";
       continue;
     }
-    TablePrinter::printElement(c->get_fov(), 14);
+    TablePrinter::printElement(c->get_fov(), 12);
     std::cout << " | ";
     TablePrinter::printElement(c->is_main_camera()? " * " : "", 14);
     std::cout << "\n";

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -1,0 +1,81 @@
+#include "includes/system/CameraSystem.hpp"
+#include "includes/utility/SimpleLogger.hpp"
+#include "includes/utility/TablePrinter.hpp"
+#include <boost/uuid/uuid_io.hpp>
+
+CameraSystem::CameraSystem() {
+  SimpleLogger::print("-- CameraSystem initialized");
+}
+
+CameraComponent *CameraSystem::create_component(uuid id, Entity *e) {
+  _components[id] = std::make_unique<CameraComponent>(id, e);
+  auto ptr = _components[id].get();
+  e->add_component(ptr);
+  if (!_main_camera) {
+    set_main_camera(ptr);
+  }
+  return ptr;
+}
+
+CameraComponent *CameraSystem::create_component(uuid id, Entity *e, float fov) {
+  auto c = create_component(id, e);
+  c->set_fov(fov);
+  return c;
+}
+
+bool CameraSystem::remove(Component *c) { return remove(c->get_uuid()); }
+bool CameraSystem::remove(uuid id) { return _components.erase(id); }
+
+std::optional<CameraComponent *> CameraSystem::get_component(uuid id) {
+  if (_components.contains(id)) {
+    return std::make_optional(_components[id].get());
+  }
+  return {};
+}
+
+void CameraSystem::set_main_camera(CameraComponent *cc) {
+  if (_main_camera) {
+    _main_camera->set_is_main_camera(false);
+  }
+  _main_camera = cc;
+  _main_camera->set_is_main_camera(true);
+  SimpleLogger::print(std::format(
+      "Set new main camera ({})\t-> camera is on entity \"{}\"({})",
+      boost::uuids::to_string(_main_camera->get_uuid()),
+      _main_camera->get_entity()->get_name(),
+      boost::uuids::to_string(_main_camera->get_entity()->get_uuid())));
+}
+
+void CameraSystem::print(){
+  TablePrinter::printElement("CameraComponent UUID", 36);
+  std::cout << " | ";
+  TablePrinter::printElement("fov", 12);
+  std::cout << " | ";
+  TablePrinter::printElement("is main camera", 14);
+  std::cout << "\n";
+  std::cout << std::string(36 + 12 + 14 + 2*3, '=');
+  std::cout << "\n";
+  for (auto const &[uuid, c] : _components) { 
+    std::cout << uuid << " | ";
+    if (c == nullptr) {
+      std::cout << "missing...\n";
+      continue;
+    }
+    TablePrinter::printElement(c->get_fov(), 14);
+    std::cout << " | ";
+    TablePrinter::printElement(c->is_main_camera()? " * " : "", 14);
+    std::cout << "\n";
+  }
+  std::cout << std::endl;
+}
+
+void CameraSystem::sample_update_move_main_camera(float t1){
+	if(!_main_camera) return;
+
+	auto ent = _main_camera->get_entity();
+	auto y = ent->get_local_position().y;
+
+
+
+
+}

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -1,7 +1,10 @@
 #include "includes/system/CameraSystem.hpp"
 #include "includes/utility/SimpleLogger.hpp"
+#include <boost/uuid/uuid_io.hpp>
 
-CameraSystem::CameraSystem() {}
+CameraSystem::CameraSystem() {
+  SimpleLogger::print("-- CameraSystem initialized");
+}
 
 CameraComponent *CameraSystem::create_component(uuid id, Entity *e) {
   _components[id] = std::make_unique<CameraComponent>(id, e);
@@ -23,12 +26,10 @@ bool CameraSystem::remove(Component *c) { return remove(c->get_uuid()); }
 bool CameraSystem::remove(uuid id) { return _components.erase(id); }
 
 std::optional<CameraComponent *> CameraSystem::get_component(uuid id) {
-  auto it = std::find_if(_components.begin(), _components.end(),
-                         [id](auto&& c) { return c.first == id; });
-  if (it != _components.end()) {
-    return std::nullopt;
+  if (_components.contains(id)) {
+    return std::make_optional(_components[id].get());
   }
-  return std::make_optional(it->second.get());
+  return {};
 }
 
 void CameraSystem::set_main_camera(CameraComponent *cc) {
@@ -37,4 +38,9 @@ void CameraSystem::set_main_camera(CameraComponent *cc) {
   }
   _main_camera = cc;
   _main_camera->set_is_main_camera(true);
+  SimpleLogger::print(std::format(
+      "Set new main camera ({})\t-> camera is on entity \"{}\"({})",
+      boost::uuids::to_string(_main_camera->get_uuid()),
+      _main_camera->get_entity()->get_name(),
+      boost::uuids::to_string(_main_camera->get_entity()->get_uuid())));
 }

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -1,0 +1,40 @@
+#include "includes/system/CameraSystem.hpp"
+#include "includes/utility/SimpleLogger.hpp"
+
+CameraSystem::CameraSystem() {}
+
+CameraComponent *CameraSystem::create_component(uuid id, Entity *e) {
+  _components[id] = std::make_unique<CameraComponent>(id, e);
+  auto ptr = _components[id].get();
+  e->add_component(ptr);
+  if (!_main_camera) {
+    set_main_camera(ptr);
+  }
+  return ptr;
+}
+
+CameraComponent *CameraSystem::create_component(uuid id, Entity *e, float fov) {
+  auto c = create_component(id, e);
+  c->set_fov(fov);
+  return c;
+}
+
+bool CameraSystem::remove(Component *c) { return remove(c->get_uuid()); }
+bool CameraSystem::remove(uuid id) { return _components.erase(id); }
+
+std::optional<CameraComponent *> CameraSystem::get_component(uuid id) {
+  auto it = std::find_if(_components.begin(), _components.end(),
+                         [id](auto&& c) { return c.first == id; });
+  if (it != _components.end()) {
+    return std::nullopt;
+  }
+  return std::make_optional(it->second.get());
+}
+
+void CameraSystem::set_main_camera(CameraComponent *cc) {
+  if (_main_camera) {
+    _main_camera->set_is_main_camera(false);
+  }
+  _main_camera = cc;
+  _main_camera->set_is_main_camera(true);
+}

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -2,6 +2,7 @@
 #include "includes/utility/SimpleLogger.hpp"
 #include "includes/utility/TablePrinter.hpp"
 #include <boost/uuid/uuid_io.hpp>
+#include <cmath>
 
 CameraSystem::CameraSystem() {
   SimpleLogger::print("-- CameraSystem initialized");
@@ -73,9 +74,9 @@ void CameraSystem::sample_update_move_main_camera(float t1){
 	if(!_main_camera) return;
 
 	auto ent = _main_camera->get_entity();
-	auto y = ent->get_local_position().y;
-
-
-
-
+	auto pos = ent->get_local_position();
+	
+	auto dt_sin = std::sin(t1 * 2.5) * 10;
+	pos.y = dt_sin;
+	ent->set_local_position(pos);
 }

--- a/Engine/core/src/system/CameraSystem.cpp
+++ b/Engine/core/src/system/CameraSystem.cpp
@@ -11,7 +11,7 @@
 #include "glm/ext.hpp"
 
 CameraSystem::CameraSystem() {
-  SimpleLogger::print("-- CameraSystem initialized");
+  SimpleLogger::print("-- created camera system");
 }
 
 CameraComponent *CameraSystem::create_component(uuid id, Entity *e) {
@@ -56,16 +56,16 @@ void CameraSystem::set_main_camera(CameraComponent *cc) {
       boost::uuids::to_string(_main_camera->get_entity()->get_uuid())));
 }
 
-void CameraSystem::print(){
+void CameraSystem::print() {
   TablePrinter::printElement("CameraComponent UUID", 36);
   std::cout << " | ";
   TablePrinter::printElement("fov", 12);
   std::cout << " | ";
   TablePrinter::printElement("is main camera", 14);
   std::cout << "\n";
-  std::cout << std::string(36 + 12 + 14 + 2*3, '=');
+  std::cout << std::string(36 + 12 + 14 + 2 * 3, '=');
   std::cout << "\n";
-  for (auto const &[uuid, c] : _components) { 
+  for (auto const &[uuid, c] : _components) {
     std::cout << uuid << " | ";
     if (c == nullptr) {
       std::cout << "missing...\n";
@@ -73,29 +73,20 @@ void CameraSystem::print(){
     }
     TablePrinter::printElement(c->get_fov(), 12);
     std::cout << " | ";
-    TablePrinter::printElement(c->is_main_camera()? " * " : "", 14);
+    TablePrinter::printElement(c->is_main_camera() ? " * " : "", 14);
     std::cout << "\n";
   }
   std::cout << std::endl;
 }
 
-void CameraSystem::sample_update_move_main_camera(float t1){
-  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 1");
-	if(!_main_camera) return;
+void CameraSystem::sample_update_move_main_camera(float t1) {
+  if (!_main_camera)
+    return;
 
-  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 2");
-	auto ent = _main_camera->get_entity();
-  SimpleLogger::print(std::format("Entity? {}", ent == nullptr));
-  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 3");
-	auto pos = ent->get_local_position();
-	std::cout << "Pos?" << pos << "\n";
-	
-  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 4");
-	auto dt_sin = std::sin(t1 * 2.5) * 10;
-  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 5");
-	pos.y = dt_sin;
-	std::cout << "Pos?" << pos << "\n";
-  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 6");
-	ent->set_local_position(pos);
-  SimpleLogger::print("CameraSystem::sample_update_move_main_camera 7");
+  auto ent = _main_camera->get_entity();
+  auto pos = ent->get_local_position();
+
+  auto dt_sin = std::sin(t1 * 2.5) * 10;
+  pos.y = dt_sin;
+  ent->set_local_position(pos);
 }

--- a/Engine/core/src/system/RenderSystem.cpp
+++ b/Engine/core/src/system/RenderSystem.cpp
@@ -35,7 +35,7 @@ void RenderSystem::init() {
     std::cout << "Failed to initialize GLAD" << std::endl;
     return;
   }
-
+  
   std::filesystem::path shader_folder(SHADER_ABSOLUTE_PATH);
   std::filesystem::path compute_shader_file =
       shader_folder / "computeshaderCircle.glsl";

--- a/Engine/core/src/system/RenderSystem.cpp
+++ b/Engine/core/src/system/RenderSystem.cpp
@@ -85,7 +85,7 @@ void RenderSystem::update(const float dt) {
   	_cameraPosition = _cs->get_main_camera()->get_entity()->get_world_position();
   }else {
 	SimpleLogger::print("-- ERROR: No main camera found -> using 0., 0., +10.");
-	_cameraPosition = glm::vec3{0., 0., 0.};
+	_cameraPosition = glm::vec3{0., 0., +10.};
   }
   glUniform3fv(_cameraU, 1, &_cameraPosition[0]);
   glUniformMatrix4fv(_projU, 1, GL_FALSE, &_projectionMatrix[0][0]);

--- a/Engine/core/src/system/RenderSystem.cpp
+++ b/Engine/core/src/system/RenderSystem.cpp
@@ -26,7 +26,7 @@
  *	  - Separate other functionality to the functions
  */
 
-RenderSystem::RenderSystem(WindowManager *wm) : System(), _wm{wm} {
+RenderSystem::RenderSystem(WindowManager *wm, CameraSystem* cs) : System(), _wm{wm}, _cs{cs} {
   SimpleLogger::print("-- created entity system");
 }
 
@@ -81,6 +81,12 @@ void RenderSystem::update(const float dt) {
   //  Setup compute shader
   compute->activateShader();
   glUniform1f(_timeU, dt);
+  if(_cs && _cs->get_main_camera()){
+  	_cameraPosition = _cs->get_main_camera()->get_entity()->get_world_position();
+  }else {
+	SimpleLogger::print("-- ERROR: No main camera found -> using 0., 0., +10.");
+	_cameraPosition = glm::vec3{0., 0., 0.};
+  }
   glUniform3fv(_cameraU, 1, &_cameraPosition[0]);
   glUniformMatrix4fv(_projU, 1, GL_FALSE, &_projectionMatrix[0][0]);
   glUniformMatrix4fv(_viewU, 1, GL_FALSE, &_viewMatrix[0][0]);

--- a/Engine/core/src/system/RenderSystem.cpp
+++ b/Engine/core/src/system/RenderSystem.cpp
@@ -28,7 +28,7 @@
 
 RenderSystem::RenderSystem(WindowManager *wm) : System(), _wm{wm} {
   SimpleLogger::print("-- created entity system");
-  }
+}
 
 void RenderSystem::init() {
   if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
@@ -39,13 +39,13 @@ void RenderSystem::init() {
   glGenVertexArrays(1, &_vao);
   glBindVertexArray(_vao);
   Shader simpleShader{
-      std::make_pair(GL_VERTEX_SHADER, "../../../../../Engine/core/shaders/vertexshader.glsl"),
+      std::make_pair(GL_VERTEX_SHADER, "../core/shaders/vertexshader.glsl"),
       std::make_pair(GL_FRAGMENT_SHADER,
-                     "../../../../../Engine/core/shaders/fragmentshader.glsl")};
+                     "../core/shaders/fragmentshader.glsl")};
   program = std::make_unique<Shader>(simpleShader);
 
   Shader computeShader{std::make_pair(
-      GL_COMPUTE_SHADER, "../../../../../Engine/core/shaders/computeshaderCircle.glsl")};
+      GL_COMPUTE_SHADER, "../core/shaders/computeshaderCircle.glsl")};
   compute = std::make_unique<Shader>(computeShader);
 
   _cameraPosition = glm::vec3(0.0f, 10.0f, 10.0f);
@@ -135,8 +135,6 @@ void RenderSystem::destroy() {
 bool RenderSystem::remove(Component *c) { throw NotImplementedError(); }
 bool RenderSystem::remove(uuid uuid) { throw NotImplementedError(); }
 
-
-
 void RenderSystem::print() {
   TablePrinter::printElement("RenderComponent UUID", 36);
   std::cout << " | ";
@@ -146,9 +144,9 @@ void RenderSystem::print() {
   std::cout << " | ";
   TablePrinter::printElement("uvVBO", 12);
   std::cout << "\n";
-  std::cout << std::string(36 + 12 + 12 + 12 + 3*3, '=');
+  std::cout << std::string(36 + 12 + 12 + 12 + 3 * 3, '=');
   std::cout << "\n";
-  for (auto const &[uuid, c] : _components) { 
+  for (auto const &[uuid, c] : _components) {
     std::cout << uuid << " | ";
     if (c == nullptr) {
       std::cout << "missing...\n";

--- a/Engine/core/src/system/RenderSystem.cpp
+++ b/Engine/core/src/system/RenderSystem.cpp
@@ -27,7 +27,7 @@
  */
 
 RenderSystem::RenderSystem(WindowManager *wm, CameraSystem* cs) : System(), _wm{wm}, _cs{cs} {
-  SimpleLogger::print("-- created entity system");
+  SimpleLogger::print("-- created render system");
 }
 
 void RenderSystem::init() {
@@ -126,6 +126,7 @@ RenderComponent *
 RenderSystem::create_component(uuid id, Entity *e,
                                const std::vector<glm::vec3> &vertices,
                                const std::vector<glm::vec2> &UV) {
+  SimpleLogger::print("-- create render component");
   _components[id] = std::make_unique<RenderComponent>(id, e, program->programID,
                                                       vertices, UV);
   auto ptr = _components[id].get();

--- a/Engine/core/src/system/RenderSystem.cpp
+++ b/Engine/core/src/system/RenderSystem.cpp
@@ -81,6 +81,7 @@ void RenderSystem::update(const float dt) {
   //  Setup compute shader
   compute->activateShader();
   glUniform1f(_timeU, dt);
+
   if(_cs && _cs->get_main_camera()){
   	_cameraPosition = _cs->get_main_camera()->get_entity()->get_world_position();
   }else {
@@ -88,6 +89,7 @@ void RenderSystem::update(const float dt) {
 	_cameraPosition = glm::vec3{0., 0., +10.};
   }
   glUniform3fv(_cameraU, 1, &_cameraPosition[0]);
+  
   glUniformMatrix4fv(_projU, 1, GL_FALSE, &_projectionMatrix[0][0]);
   glUniformMatrix4fv(_viewU, 1, GL_FALSE, &_viewMatrix[0][0]);
 

--- a/Engine/core/src/system/SimpleSystem.cpp
+++ b/Engine/core/src/system/SimpleSystem.cpp
@@ -1,6 +1,7 @@
 #include "includes/system/SimpleSystem.hpp"
 #include "includes/Entity.hpp"
 #include "includes/component/SimpleComponent.hpp"
+#include "includes/utility/SimpleLogger.hpp"
 #include <boost/uuid/uuid_io.hpp>
 #include <iostream>
 #include <memory>

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -5,7 +5,6 @@
 int main() {
   SimpleLogger::print("=== APP STARTED ===");
   Engine engine{};
-  SimpleLogger::print("=== START LOOP ===");
   engine.startLoop();
   SimpleLogger::print("=== APP ENDED ===");
   return 0;


### PR DESCRIPTION
moving the ecs will now move a designated main camera. main camera is known by the render system and is accessed each render/update call
currently only position is given to the ray tracer

TODO:
- add rotation to shader script(s)
- add FoV to shader script(s)
- add handy function like "lookAt" to camera component (might be useful for moving the camera in the UI)